### PR TITLE
Fix intermediate colors in gradients

### DIFF
--- a/rappar.js
+++ b/rappar.js
@@ -436,7 +436,7 @@ function rappar(svg) {
         for (var i = 0, ii = grad.stops.length; i < ii; i++) {
             stop = grad.stops[i];
             if (i && i != ii - 1) {
-                s.push(stop.offset + ":" + stop.color);
+                s.push(stop.color + ":" + stop.offset);
             } else {
                 s.push(stop.color);
             }
@@ -456,7 +456,7 @@ function rappar(svg) {
         for (var i = 0, ii = grad.stops.length; i < ii; i++) {
             stop = grad.stops[i];
             if (i && i != ii - 1) {
-                s.push(stop.offset + ":" + stop.color);
+                s.push(stop.color + ":" + stop.offset);
             } else {
                 s.push(stop.color);
             }


### PR DESCRIPTION
Intermediate colors in gradients should be formatted as `color:offset`, not `offset:color`.

From the Raphael documentation: http://raphaeljs.com/reference.html#Element.attr

![image](https://f.cloud.github.com/assets/1017630/1948845/3b4d6384-80bb-11e3-8c73-7bfe5215fe1e.png)
