### PR TITLE
"Str" is not defined

### DIFF
--- a/rappar.js
+++ b/rappar.js
@@ -217,7 +217,7 @@ function Matrix(a, b, c, d, e, f) {
         return x * this.b + y * this.d + this.f;
     };
     matrixproto.get = function (i) {
-        return +this[Str.fromCharCode(97 + i)].toFixed(4);
+        return +this[String.fromCharCode(97 + i)].toFixed(4);
     };
     matrixproto.toString = function () {
         return R.svg ?


### PR DESCRIPTION
Hello everybody!

When I tried to convert SVG to Raphael JSON format I had an error. I think that is a typo error, but I am not sure. I hope that it helps.

``` code
$ node rappar.js file.svg > test.txt
/terox/rappar.js:220
        return +this[Str.fromCharCode(97 + i)].toFixed(4);
                     ^

ReferenceError: Str is not defined
    at Matrix.matrixproto.get (/terox/rappar.js:220:22)
    at Matrix.matrixproto.toTransformString (/terox/rappar.js:309:32)
    at parseTransform (/terox/rappar.js:514:14)
    at Object.<anonymous> (/terox/rappar.js:347:26)
    at eve (/terox/eve.js:85:32)
    at /terox/rappar.js:419:13
    at eve (/terox/eve.js:85:32)
    at Function.d [as event] (/terox/elemental.js:10:349)
    at Function.h.attr (/terox/elemental.js:10:3918)
    at Function.h.attr start (/terox/elemental.js:10:3594)
```
